### PR TITLE
feat: bump nginx to 1.28.3-alpine and add ngx_otel_module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-ARG BASE_IMAGE="nginx:1.24.0-alpine"
+# nginx:1.28.3-alpine
+ARG BASE_IMAGE="nginx@sha256:a8b39bd9cf0f83869a2162827a0caf6137ddf759d50a171451b335cecc87d236"
 
 FROM $BASE_IMAGE as builder
 
-ARG ENABLED_MODULES="brotli headers-more vts"
+ARG ENABLED_MODULES="brotli headers-more vts otel"
 
 RUN set -ex \
     && if [ "$ENABLED_MODULES" = "" ]; then \
@@ -15,12 +16,12 @@ COPY modules /modules/
 RUN set -ex \
     && apk update \
     && apk add linux-headers openssl-dev pcre2-dev zlib-dev openssl abuild \
-               musl-dev libxslt libxml2-utils make mercurial gcc unzip git \
+               musl-dev libxslt libxml2-utils make gcc unzip git \
                xz g++ coreutils \
     # allow abuild as a root user \
     && printf "#!/bin/sh\\nSETFATTR=true /usr/bin/abuild -F \"\$@\"\\n" > /usr/local/bin/abuild \
     && chmod +x /usr/local/bin/abuild \
-    && hg clone -r ${NGINX_VERSION}-${PKG_RELEASE} https://hg.nginx.org/pkg-oss/ \
+    && git clone --branch ${NGINX_VERSION}-${PKG_RELEASE} --depth 1 https://github.com/nginx/pkg-oss.git \
     && cd pkg-oss \
     && mkdir /tmp/packages \
     && for module in $ENABLED_MODULES; do \

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Modules that are available by default:
 * [ngx_brotli](https://github.com/google/ngx_brotli) - Brotli compression
 * [ngx_http_headers_more_filter_module](https://github.com/openresty/headers-more-nginx-module) - Set, add, and clear arbitrary output headers in NGINX http servers
 * [ngx_http_vhost_traffic_status_module](https://github.com/vozlt/nginx-module-vts) - Nginx virtual host traffic status
+* [ngx_otel_module](https://nginx.org/en/docs/ngx_otel_module.html) - OpenTelemetry tracing (W3C trace context propagation, OTLP/gRPC exporter)
 
 License
 -------

--- a/etc/nginx/modules.conf
+++ b/etc/nginx/modules.conf
@@ -4,3 +4,5 @@ load_module "modules/ngx_http_brotli_static_module.so";
 load_module "modules/ngx_http_headers_more_filter_module.so";
 
 load_module "modules/ngx_http_vhost_traffic_status_module.so";
+
+load_module "modules/ngx_otel_module.so";


### PR DESCRIPTION
- bump BASE_IMAGE to nginx@sha256:a8b39bd9cf0f83869a2162827a0caf6137ddf759d50a171451b335cecc87d236 (nginx:1.28.3-alpine; required for ngx_otel_module which needs nginx >=1.25.3)
- add otel to default ENABLED_MODULES (pkg-oss BASE_MODULES already includes it)
- load ngx_otel_module.so in modules.conf
- migrate pkg-oss source from hg.nginx.org (decommissioned) to github.com/nginx/pkg-oss
- drop mercurial build dependency, no longer needed after git migration

The OpenTelemetry module enables W3C trace context propagation, OTLP/gRPC exporter and exposes $otel_trace_id / $otel_span_id variables for use in access_log formats. The module is inert until otel_trace is enabled in downstream configuration.